### PR TITLE
Added ability to switch to azure mode RST-1666

### DIFF
--- a/lib/rails_container/config/environments/production.rb
+++ b/lib/rails_container/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :amazon
+  config.active_storage.service = ENV.fetch('CLOUD_PROVIDER', 'amazon').to_sym
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true

--- a/lib/rails_container/config/storage.yml
+++ b/lib/rails_container/config/storage.yml
@@ -17,6 +17,13 @@ amazon:
   bucket: <%= ENV.fetch('S3_UPLOAD_BUCKET', '') %>
   <%= "endpoint: #{ENV.fetch('AWS_ENDPOINT')}" if ENV.key?('AWS_ENDPOINT') %>
   <%= "force_path_style: true" if ENV.fetch('AWS_S3_FORCE_PATH_STYLE', 'false') == 'true' %>
+azure:
+  service: AzureStorage
+  storage_account_name: <%= ENV.fetch('AZURE_STORAGE_ACCOUNT', 'devstoreaccount1') %>
+  storage_access_key: <%= ENV.fetch('AZURE_STORAGE_ACCESS_KEY', 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==') %>
+  container: <%= ENV.fetch('AZURE_STORAGE_CONTAINER', 'et_api_container') %>
+  <%= "use_path_style_uri: true" if ENV.fetch('AZURE_STORAGE_BLOB_FORCE_PATH_STYLE', 'false') == 'true' %>
+  <%= "storage_blob_host: '#{ENV['AZURE_STORAGE_BLOB_HOST']}'" if ENV.key?('AZURE_STORAGE_BLOB_HOST') %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
This PR allows the production environment to be used in azure mode using the same environment variable that is used in the API - 'CLOUD_PROVIDER' - can be either 'amazon' or 'azure' - or left blank for amazon