### PR TITLE
ubuntu version changed from 16.04 to latest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,8 +27,8 @@ jobs:
 - job: TestApplication
 
   pool:
-    vmImage: 'Ubuntu-16.04'
-  
+    vmImage: 'ubuntu-latest'
+
   steps:
   - task: UseRubyVersion@0
     inputs:
@@ -86,7 +86,7 @@ jobs:
   dependsOn: TestApplication
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
   pool:
-    vmImage: 'Ubuntu-16.04'
+    vmImage: 'ubuntu-latest'
   steps:
 
   - bash: |
@@ -116,7 +116,7 @@ jobs:
       azureContainerRegistry: $(azure.container.registry)
       command: 'Tag image'
       imageName: '$(application.name):$(getDockerTag.DOCKER_TAG)'
-    
+
   - task: Docker@1
     displayName: 'Push an image'
     inputs:
@@ -135,7 +135,7 @@ jobs:
   dependsOn: TestApplication
   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/develop'), eq(variables['Build.Reason'], 'Manual'))
   pool:
-    vmImage: 'Ubuntu-16.04'  # name of the pool to run this job in
+    vmImage: 'ubuntu-latest'  # name of the pool to run this job in
   steps:
 
   - bash: |
@@ -166,7 +166,7 @@ jobs:
       azureContainerRegistry: $(azure.container.registry)
       command: 'Tag image'
       imageName: '$(application.name):$(getDockerTag.DOCKER_TAG)'
-    
+
   - task: Docker@1
     displayName: 'Push an image'
     inputs:


### PR DESCRIPTION
JIRA link: [DTSPO-4322](https://tools.hmcts.net/jira/browse/DTSPO-4322)

Ubuntu 16.04 LTS environment is deprecated and will be removed on September 20, 2021. 
Ubuntu version upgraded from 16.04 to latest

**Does this PR introduce a breaking change?** (check one with "x")
[  ] Yes
[X] No